### PR TITLE
Fix wrapText empty line bug

### DIFF
--- a/app.js
+++ b/app.js
@@ -315,13 +315,19 @@ function wrapText(ctx, text, maxWidth) {
     const testWidth = metrics.width;
 
     if (testWidth > maxWidth) {
-      lines.push(line.trim());
-      line = word + " ";
+      if (line !== "") {
+        lines.push(line.trim());
+        line = word + " ";
+      } else {
+        // 单词本身已超出宽度，直接换行避免空行
+        lines.push(word);
+        line = "";
+      }
     } else {
       line = testLine;
     }
   }
-  lines.push(line.trim());
+  if (line.trim() !== "") lines.push(line.trim());
   return lines;
 }
 


### PR DESCRIPTION
## Summary
- handle extremely long words in `wrapText` to avoid blank lines

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68472bc75ba88322bc6eb483de09372c